### PR TITLE
Fix Mod Customisation Container not absorbing input correctly

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSettings.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSettings.cs
@@ -101,7 +101,6 @@ namespace osu.Game.Tests.Visual.UserInterface
         [Test]
         public void TestCustomisationMenuNoClickthrough()
         {
-
             createModSelect();
             openModSelect();
 
@@ -116,12 +115,6 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddAssert("only cm2 is active", () => SelectedMods.Value.Count == 1);
         }
 
-
-
-        private void clickPosition(int x, int y) {
-            //Move cursor to coordinates
-            //Click coordinates
-        }
         private void createModSelect()
         {
             AddStep("create mod select", () =>
@@ -148,20 +141,19 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             public bool ButtonsLoaded => ModSectionsContainer.Children.All(c => c.ModIconsLoaded);
 
-            public void SelectMod(Mod mod) =>
-                ModSectionsContainer.Children.Single(s => s.ModType == mod.Type)
-                                    .ButtonsContainer.OfType<ModButton>().Single(b => b.Mods.Any(m => m.GetType() == mod.GetType())).SelectNext(1);
-            
             public ModButton GetModButton(Mod mod)
             {
-                return ModSectionsContainer.Children.Single(s => s.ModType == mod.Type).
-                                            ButtonsContainer.OfType<ModButton>().Single(b => b.Mods.Any(m => m.GetType() == mod.GetType()));
+                return ModSectionsContainer.Children.Single(s => s.ModType == mod.Type)
+                                           .ButtonsContainer.OfType<ModButton>().Single(b => b.Mods.Any(m => m.GetType() == mod.GetType()));
             }
 
-            public float SetModSettingsWidth(float NewWidth)
+            public void SelectMod(Mod mod) =>
+                GetModButton(mod).SelectNext(1);
+
+            public float SetModSettingsWidth(float newWidth)
             {
                 float oldWidth = ModSettingsContainer.Width;
-                ModSettingsContainer.Width = NewWidth;
+                ModSettingsContainer.Width = newWidth;
                 return oldWidth;
             }
         }

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -284,7 +284,7 @@ namespace osu.Game.Overlays.Mods
                         },
                     },
                 },
-                ModSettingsContainer = new CModSettingsContainer
+                ModSettingsContainer = new MouseInputAbsorbingContainer
                 {
                     RelativeSizeAxes = Axes.Both,
                     Anchor = Anchor.BottomRight,
@@ -496,17 +496,11 @@ namespace osu.Game.Overlays.Mods
 
         #endregion
 
-        protected class CModSettingsContainer : Container
+        protected class MouseInputAbsorbingContainer : Container
         {
-            protected override bool OnMouseDown(MouseDownEvent e)
-            {
-                return true;
-            }
+            protected override bool OnMouseDown(MouseDownEvent e) => true;
 
-            protected override bool OnHover(HoverEvent e)
-            {
-                return true;
-            }
+            protected override bool OnHover(HoverEvent e) => true;
         }
     }
 }

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -508,6 +508,5 @@ namespace osu.Game.Overlays.Mods
                 return true;
             }
         }
-
     }
 }

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -284,7 +284,7 @@ namespace osu.Game.Overlays.Mods
                         },
                     },
                 },
-                ModSettingsContainer = new Container
+                ModSettingsContainer = new CModSettingsContainer
                 {
                     RelativeSizeAxes = Axes.Both,
                     Anchor = Anchor.BottomRight,
@@ -495,5 +495,19 @@ namespace osu.Game.Overlays.Mods
         }
 
         #endregion
+
+        protected class CModSettingsContainer : Container
+        {
+            protected override bool OnMouseDown(MouseDownEvent e)
+            {
+                return true;
+            }
+
+            protected override bool OnHover(HoverEvent e)
+            {
+                return true;
+            }
+        }
+
     }
 }


### PR DESCRIPTION
Fixes 10210

Previously hovering and right clicks were passed throught the customisation menu to buttons behind it. Left clicks were and are absorbed by the `OsuScrollContainer` inside `ModSettingsContainer`. Mouse clicks and hover events are now absorbed by `ModSettingsContainer`.

I'm honestly not sure whether the way I have implemented the testing is correct or too hacky, if there is an easier way and if testing is even worth it for this issue.

Messing with pull requests right now
I didn't know the issue thread would link to this i apologize

